### PR TITLE
Handle rails logs with decimal total duration values

### DIFF
--- a/lib/log_agent/filter/rails.rb
+++ b/lib/log_agent/filter/rails.rb
@@ -23,7 +23,7 @@ module LogAgent::Filter
         event.fields['rails_redirect'] = $1
       end
 
-      if event.message =~ /^Completed (\d+) .* in (\d+)ms/
+      if event.message =~ /^Completed (\d+) .* in (\d+(?:\.\d+)?)ms/
         event.fields['rails_status'] = $1.to_i
         event.fields['rails_duration']['total'] = $2.to_f
       end

--- a/spec/data/rails_entries/entry3.log
+++ b/spec/data/rails_entries/entry3.log
@@ -19,4 +19,4 @@ Rendered shared/_work_subnav.html.erb (2.1ms)
 Rendered invoices/_subnav.html.erb (2.2ms)
 Rendered invoices/show.html.erb within layouts/application (57.2ms)
 RequestCache: 0 hits out of 1 cache tests = 0% efficiency
-Completed 200 OK in 78ms (Views: 55.2ms | ActiveRecord: 65.5ms)
+Completed 200 OK in 120.7ms (Views: 55.2ms | ActiveRecord: 65.5ms)

--- a/spec/functional/filter/rails_spec.rb
+++ b/spec/functional/filter/rails_spec.rb
@@ -174,7 +174,7 @@ describe LogAgent::Filter::Rails do
     it "should parse the total duration and breakdown" do
       entry1.fields['rails_duration'].should == {"total" => 12, "views" => 0.9, "activerecord" => 4.7}
       entry2.fields['rails_duration'].should == {"total" => 6, "views" => 5.5, "activerecord" => 0.0}
-      entry3.fields['rails_duration'].should == {"total" => 78, "views" => 55.2, "activerecord" => 65.5}
+      entry3.fields['rails_duration'].should == {"total" => 120.7, "views" => 55.2, "activerecord" => 65.5}
       entry4.fields['rails_duration'].should == {"total" => 28}
       entry5.fields['rails_duration'].should == {"total" => 12}
       entry6.fields['rails_duration'].should == {"total" => 133, "views" => 35.3, "activerecord" => 57.0}


### PR DESCRIPTION
Rails 3 upgrade changed this I believe. Logs can now contain decimal values (`/\d+\.\d+/`) for the total duration value; which we didn't parse out before now. Update the code & tests to make sure we handle this case.
