### PR TITLE
Rails stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    log_agent (1.3.2)
+    log_agent (1.4.1)
+      amq-protocol (= 1.9.2)
       amqp (~> 1.3)
       daemons (~> 1.1.8)
       eventmachine (~> 0.12.10)
@@ -13,7 +14,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     amq-protocol (1.9.2)
-    amqp (1.3.0)
+    amqp (1.5.0)
       amq-protocol (>= 1.9.2)
       eventmachine
     daemons (1.1.9)
@@ -22,8 +23,8 @@ GEM
     eventmachine (0.12.10)
     eventmachine-tail (0.6.4)
       eventmachine
-    json (1.5.4)
-    macaddr (1.6.7)
+    json (1.5.5)
+    macaddr (1.7.1)
       systemu (~> 2.6.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
@@ -33,9 +34,9 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    systemu (2.6.4)
+    systemu (2.6.5)
     timecop (0.6.1)
-    uuid (2.3.7)
+    uuid (2.3.8)
       macaddr (~> 1.0)
 
 PLATFORMS
@@ -46,3 +47,6 @@ DEPENDENCIES
   log_agent!
   rspec
   timecop
+
+BUNDLED WITH
+   1.10.6

--- a/lib/log_agent/filter/rails.rb
+++ b/lib/log_agent/filter/rails.rb
@@ -100,10 +100,6 @@ module LogAgent::Filter
         composed_data.each do |field,value|
           # Do not add pid, already taken care of else where
           next if field == "pid"
-          # If it is a positive value drop the sign
-          if value =~ /^\+/
-            value = value[1..-1]
-          end
           event.fields[field] = value.to_i
         end
       end

--- a/lib/log_agent/filter/rails.rb
+++ b/lib/log_agent/filter/rails.rb
@@ -1,6 +1,6 @@
 module LogAgent::Filter
   class Rails < Base
-    
+
     include LogAgent::LogHelper
 
     def << event
@@ -64,13 +64,57 @@ module LogAgent::Filter
         event.fields['rails_session'] = $1
       end
 
+      # parse GC stats line
+      # GC stats (23064):1255 (+0) major, 1304 (+0) minor, 10383 allocations,
+      # 1808374 (+10383) live slots, 2311088 (+0) total slots, 16076440 (+469608) memory
+      # See app/controllers/concerns/memory_instrumentation.rb in the FA app
+      # and http://thorstenball.com/blog/2014/03/12/watching-understanding-ruby-2.1-garbage-collector/
+      # for a useful description of the values
+      if event.message =~ /^GC stats/
+
+        # Defines field order and headings
+        gc_field_order = [
+          "pid",
+          "major_gc_total",
+          "major_gc",
+          "minor_gc_total",
+          "minor_gc",
+          "object_allocations",
+          "live_slots_total",
+          "live_slots",
+          "total_slots_total",
+          "total_slots",
+          "oldmalloc_bytes_total",
+          "oldmalloc_bytes",
+        ]
+
+        # Pull out the data using a regexp
+        data_values = event.message.match(/GC stats \((\d+\)):(\d+) \((.\d+\)) major, (\d+) \((.\d+\)) minor, (\d+) allocations, (\d+) \((.\d+\)) live slots, (\d+) \((.\d+\)) total slots, (\d+) \((.\d+\)) memory/)
+
+        # Turn our array of data, and field names into a hash for ease
+        # of use. First element of data_values is the whole matched string so do not
+        # include that.
+        composed_data = Hash[*gc_field_order.zip(data_values[1..-1]).flatten.compact]
+
+        # Add fields to the event
+        composed_data.each do |field,value|
+          # Do not add pid, already taken care of else where
+          next if field == "pid"
+          # If it is a positive value drop the sign
+          if value =~ /^\+/
+            value = value[1..-1]
+          end
+          event.fields[field] = value.to_i
+        end
+      end
+
       event.fields['rails_queries'] ||= { "total" => 0 }
       event.message.scan(/ActiveRecord: (\d+) ([A-Za-z]+) queries/) do |count,verb|
         count = count.to_i
         event.fields['rails_queries'][verb] = count
         event.fields['rails_queries']['total'] += count
       end
-      
+
       event.fields['rails_rendered'] = []
       event.message.scan(/Rendered (.+?) (?:within (.*) )?\(([\d.]+)ms\)/) do |match|
         template = {"name" => match[0], "duration" => match[2].to_f}
@@ -80,6 +124,6 @@ module LogAgent::Filter
 
       emit event
     end
-    
+
   end
 end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/log_agent.gemspec
+++ b/log_agent.gemspec
@@ -97,6 +97,7 @@ Gem::Specification.new do |s|
     spec/data/rails_entries/entry5.log
     spec/data/rails_entries/entry6.log
     spec/data/rails_entries/entry7.log
+    spec/data/rails_entries/entry8.log
     spec/data/rails_multiline_message_entries/log_file1.log
     spec/data/ruby_log_formatter_entries/entry1.log
     spec/data/ruby_log_formatter_entries/entry2.log
@@ -137,6 +138,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.5.4'
   s.add_runtime_dependency 'daemons', '~> 1.1.8'
   s.add_runtime_dependency 'eventmachine-tail', '~> 0.6.3'
+  s.add_runtime_dependency 'amq-protocol', '1.9.2'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'evented-spec'

--- a/spec/data/rails_entries/entry8.log
+++ b/spec/data/rails_entries/entry8.log
@@ -1,0 +1,10 @@
+Started GET "/signup" for 127.0.0.1 at 2015-08-23 05:44:05 +0000
+Processing by SignupController#index as HTML
+  Rendered shared/_flash.html.erb (0.4ms)
+  Rendered signup/_password_strength_meter.html.erb (0.2ms)
+Loaded session 'af9b23d3a01b709d10cc29458429810b'
+  Rendered signup/index.html.erb within layouts/signup (9.2ms)
+  Rendered layouts/_head.html.erb (0.2ms)
+  Rendered layouts/_typekit_load.html.erb (0.2ms)
+ActiveRecord: 8 SELECT queries
+GC stats (4482):190 (+0) major, 1353 (+0) minor, 8398 allocations, 1877377 (+8398) live slots, 2625715 (+0) total slots, 12750672 (+377920) memory

--- a/spec/functional/filter/rails_spec.rb
+++ b/spec/functional/filter/rails_spec.rb
@@ -211,6 +211,20 @@ describe LogAgent::Filter::Rails do
 
       entry6.fields['rails_queries'].should == { "total" => 0 }
     end
+
+    it "should add the GC stats as fields" do
+      entry8.fields['major_gc_total'].should == 190
+      entry8.fields['major_gc'].should == 0
+      entry8.fields['minor_gc_total'].should == 1353
+      entry8.fields['minor_gc'].should == 0
+      entry8.fields['object_allocations'].should == 8398
+      entry8.fields['live_slots_total'].should == 1877377
+      entry8.fields['live_slots'].should == 8398
+      entry8.fields['total_slots_total'].should == 2625715
+      entry8.fields['total_slots'].should == 0
+      entry8.fields['oldmalloc_bytes_total'].should == 12750672
+      entry8.fields['oldmalloc_bytes'].should == 377920
+    end
   end
 end
 


### PR DESCRIPTION
- Adds support for adding the rails GC stats as ES fields.
- Updates amq-protocol gem (and hence amqp gem) to 1.9.2 and pins it.
  Any newer releases only work with ruby > version 2. we should probably
  start to make ops tools work with ruby 2.1. With out this fix the current production is gem at this point in time not installable.
- Adds test for parsing GC stats to check for correct stats.