### PR TITLE
Enable message persistence so messages survive broker restart

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    log_agent (1.5.0)
+    log_agent (1.5.2)
       amq-protocol (= 1.9.2)
       amqp (~> 1.3)
       daemons (~> 1.1.8)
@@ -47,3 +47,6 @@ DEPENDENCIES
   log_agent!
   rspec
   timecop
+
+BUNDLED WITH
+   1.11.2

--- a/lib/log_agent/output/amqp.rb
+++ b/lib/log_agent/output/amqp.rb
@@ -9,7 +9,7 @@ module LogAgent::Output
     
     def << event
       debug "Shipping event '#{event.uuid}'"
-      @exchange.publish(event.to_payload, :routing_key => "#{event.type}.#{event.source_host}") do 
+      @exchange.publish(event.to_payload, :routing_key => "#{event.type}.#{event.source_host}", :persistent => true) do
         yield if block_given?
       end
     end

--- a/lib/log_agent/output/amqp.rb
+++ b/lib/log_agent/output/amqp.rb
@@ -1,15 +1,25 @@
 module LogAgent::Output
   class AMQP
     include LogAgent::LogHelper
-    
-    attr_reader :channel, :exchange
-    def initialize channel, exchange
-      @channel, @exchange = channel, exchange
+
+    attr_reader :channel, :exchange, :persistent_msgs
+    # Initialise AMQP output module
+    #
+    # * channel - Bunny channle
+    # * exchange - Bunny exchange
+    # * persistent_msgs - Should messages survive a broker restart
+    #   persistent_msgs defaults to true.
+    def initialize(channel, exchange, persistent_msgs = true)
+      @channel, @exchange, @persistent_msgs = channel, exchange, persistent_msgs
     end
-    
+
     def << event
       debug "Shipping event '#{event.uuid}'"
-      @exchange.publish(event.to_payload, :routing_key => "#{event.type}.#{event.source_host}", :persistent => true) do
+      @exchange.publish(
+        event.to_payload,
+        :routing_key => "#{event.type}.#{event.source_host}",
+        :persistent  => persistent_msgs
+      ) do
         yield if block_given?
       end
     end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end


### PR DESCRIPTION
By default messages are not persistent. To persist them so they survive
a broker restart they must be explicitly set to do so.