### PR TITLE
Make sure ES output uses persistent messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    log_agent (1.5.2)
+    log_agent (1.5.3)
       amq-protocol (= 1.9.2)
       amqp (~> 1.3)
       daemons (~> 1.1.8)

--- a/lib/log_agent/output/amqp.rb
+++ b/lib/log_agent/output/amqp.rb
@@ -5,7 +5,7 @@ module LogAgent::Output
     attr_reader :channel, :exchange, :persistent_msgs
     # Initialise AMQP output module
     #
-    # * channel - Bunny channle
+    # * channel - Bunny channel
     # * exchange - Bunny exchange
     # * persistent_msgs - Should messages survive a broker restart
     #   persistent_msgs defaults to true.
@@ -18,7 +18,7 @@ module LogAgent::Output
       @exchange.publish(
         event.to_payload,
         :routing_key => "#{event.type}.#{event.source_host}",
-        :persistent  => persistent_msgs
+        :persistent  => @persistent_msgs
       ) do
         yield if block_given?
       end

--- a/lib/log_agent/output/elasticsearch_river.rb
+++ b/lib/log_agent/output/elasticsearch_river.rb
@@ -2,8 +2,8 @@ module LogAgent::Output
   class ElasticsearchRiver
     attr_reader :channel, :exchange, :routing_key
 
-    def initialize( channel, exchange, routing_key )
-      @channel, @routing_key = channel, routing_key
+    def initialize( channel, exchange, routing_key, persistent_msgs = true )
+      @channel, @routing_key, @persistent_msgs = channel, routing_key, persistent_msgs
       @exchange = if exchange.is_a? ::AMQP::Exchange
         exchange
       else
@@ -19,7 +19,7 @@ module LogAgent::Output
         "_id"         => event.uuid
       }}
 
-      @exchange.publish( [JSON.dump(action),event.to_payload,""].join("\n"), :routing_key => @routing_key ) do
+      @exchange.publish( [JSON.dump(action),event.to_payload,""].join("\n"), :routing_key => @routing_key, :persistent => @persistent_msgs ) do
         yield if block_given?
       end
     end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end


### PR DESCRIPTION
- There are two output types that use AMQP, the AMQP output module and
  the ES River module. Make sure both use persistent messages.