### PR TITLE
Make sure we don't depend on amqp >= 1.6 for now.

### DIFF
--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.5.3'
+  VERSION = '1.5.4'
 end

--- a/log_agent.gemspec
+++ b/log_agent.gemspec
@@ -133,7 +133,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'eventmachine', '~> 0.12.10'
-  s.add_runtime_dependency 'amqp', '~> 1.3'
+  s.add_runtime_dependency 'amqp', '~> 1.5.0'
   s.add_runtime_dependency 'uuid', '~> 2.3.5'
   s.add_runtime_dependency 'json', '~> 1.5.4'
   s.add_runtime_dependency 'daemons', '~> 1.1.8'


### PR DESCRIPTION
amqp >= 1.6.0 requires amq-protocol 2.0.1 which breaks our own hard
dependency on amq-protocol 1.9.2

For now lets just make sure we don't install amqp 1.6.0 until we get
time to test with the new amq-protocol gem.