### PR TITLE
Fill in missing json_event fields in FileTail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    log_agent (1.7.0pre1)
+    log_agent (1.7.1)
       amq-protocol (= 1.9.2)
       amqp (~> 1.5.0)
       daemons (~> 1.1.8)
@@ -51,4 +51,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/lib/log_agent/event.rb
+++ b/lib/log_agent/event.rb
@@ -4,7 +4,8 @@ module LogAgent
   class Event
     include LogAgent::LogHelper
 
-    attr_reader :source_type, :source_host, :source_path, :uuid
+    attr_reader :uuid
+    attr_accessor :source_type, :source_host, :source_path
     attr_accessor :tags, :fields
     attr_accessor :type, :message, :message_format, :timestamp, :captured_at
 

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.7.1pre3'
+  VERSION = '1.7.1'
 end

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -176,11 +176,6 @@ describe LogAgent::Event, "behaviour" do
       empty_event.source_type.should == ''
       event.source_type.should == 'file'
     end
-    it "should be immutable" do
-      lambda { event.source_type = 'fish' }.should raise_error
-      lambda { event.source_path = 'fish' }.should raise_error
-      lambda { event.source_host = 'fish' }.should raise_error
-    end
   end
 
   describe "Event.from_payload" do


### PR DESCRIPTION
When using the json_event format, fill in the source_path, source_type,
type and tags fields when they are not included in the message itself.