### PR TITLE
Pass through any additional fields in a payload

### DIFF
--- a/lib/log_agent/output/debug.rb
+++ b/lib/log_agent/output/debug.rb
@@ -1,13 +1,13 @@
 module LogAgent::Output
   class Debug
     include LogAgent::LogHelper
-    
+
     def initialize
     end
-    
+
     def << event
       debug "Shipping event '#{event.uuid}'"
-      info event.inspect
+      info event.to_payload
     end
   end
 end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.7.2'
+  VERSION = '1.8.0'
 end

--- a/spec/functional/input/file_tail_spec.rb
+++ b/spec/functional/input/file_tail_spec.rb
@@ -129,6 +129,14 @@ describe LogAgent::Input::FileTail do
       }
       EM.add_timer(0.1) { logfile1.puts LogAgent::Event.new(:uuid => "1122334").to_payload; logfile1.flush }
     end
+    it "should pass through top level fields" do
+      sink.should_receive(:<<) { |event|
+        JSON.parse(event.to_payload)["foo"].should == 'bar'
+        done
+      }
+      EM.add_timer(0.1) { logfile1.puts ({ foo: "bar"}).to_json; logfile1.flush }
+    end
+
     it "should populate the message if the creation fails" do
       LogAgent.logger.should_receive(:warn)
       sink.should_receive(:<<) { |event|


### PR DESCRIPTION
After parsing an event for known fields, store the remaining unknown
ones and pass them back out when emiting the payload.