### PR TITLE
Add an operation id log message parser

### DIFF
--- a/lib/log_agent.rb
+++ b/lib/log_agent.rb
@@ -28,6 +28,7 @@ module LogAgent
     autoload 'RailsMultilineMessage', 'log_agent/filter/rails_multiline_message'
     autoload 'PidDemuxer',            'log_agent/filter/pid_demuxer'
     autoload 'RailsLogTagParser',     'log_agent/filter/rails_log_tag_parser'
+    autoload 'RailsOpIdParser',       'log_agent/filter/rails_op_id_parser'
     autoload 'MysqlSlow',             'log_agent/filter/mysql_slow'
   end
   module Output

--- a/lib/log_agent/event.rb
+++ b/lib/log_agent/event.rb
@@ -9,6 +9,7 @@ module LogAgent
     attr_accessor :tags, :fields
     attr_accessor :type, :message, :message_format, :timestamp, :captured_at
     attr_reader :top_level_fields
+    attr_accessor :op_id
 
     def self.reduce(events, &reducer)
       reducer ||= lambda do |messages|
@@ -44,6 +45,7 @@ module LogAgent
       @timestamp = opts[:timestamp] || Time.now
       @fields = opts[:fields] || {}
       @top_level_fields = opts[:top_level_fields] || {}
+      @op_id = opts[:op_id]
       debug "Event '#{@uuid}' created"
     end
 
@@ -87,7 +89,8 @@ module LogAgent
         '@message'      => self.message,
         '@tags'         => self.tags,
         '@type'         => self.type,
-        '@uuid'         => self.uuid
+        '@uuid'         => self.uuid,
+        '@op_id'        => self.op_id
       }.merge(top_level_fields)).tap { |json| debug json }
     end
 

--- a/lib/log_agent/filter/rails_log_tag_parser.rb
+++ b/lib/log_agent/filter/rails_log_tag_parser.rb
@@ -6,9 +6,9 @@ module LogAgent
       # Public: Read the list of configured tags
       #
       # Returns: A hash of the form:
-      #  
+      #
       #   { "tag" => "field_name", ... }
-      # 
+      #
       # where "tag" is the tag name in the log and "field_name" is the
       # name of the field in the log event. Even if the two are the same
       attr_reader :tags

--- a/lib/log_agent/filter/rails_op_id_parser.rb
+++ b/lib/log_agent/filter/rails_op_id_parser.rb
@@ -1,0 +1,26 @@
+require 'strscan'
+module LogAgent
+  module Filter
+    class RailsOpIdParser < Base
+
+      # Public: Creates an instance
+      #
+      # sink - the next Filter / Output in the chain
+      def initialize(sink)
+        super(sink)
+      end
+
+      # Public: Pass an event through this filter.
+      def << event
+        out_message = nil
+
+        if (match_data = event.message.match(/(.*)\[op=([^\]]+)\]\s(.*)/))
+          event.op_id = match_data[2]
+          event.message = "#{match_data[1]}#{match_data[3]}"
+        end
+
+        super(event)
+      end
+    end
+  end
+end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.8.0'
+  VERSION = '1.9.0-pre.1'
 end

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.9.0-pre.1'
+  VERSION = '1.9.0'
 end

--- a/spec/functional/filter/rails_op_id_parser_spec.rb
+++ b/spec/functional/filter/rails_op_id_parser_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe LogAgent::Filter::RailsOpIdParser do
+  let(:sink)   { mock("Sink",  :<< => nil) }
+  let(:filter) { LogAgent::Filter::RailsOpIdParser.new(sink)}
+
+  it "should pass on any log messages that don't contain a log tag" do
+    sink.should_receive(:<<) do |event|
+      event.message.should == "a message"
+    end
+    filter << LogAgent::Event.new(:message => "a message")
+  end
+
+  it "should pass on any unrecognised tags" do
+    sink.should_receive(:<<) { |event| event.message.should == "[random_tag=stuff] Something happened!" }
+
+    filter << LogAgent::Event.new(:message => "[random_tag=stuff] Something happened!")
+  end
+
+  describe "when a recognised tag is found" do
+    before do
+      sink.should_receive(:<<).with { |event| @event = event }
+    end
+
+    it "should remove the tag text from the message" do
+      filter << LogAgent::Event.new(:message => "[op=1234] Some text")
+      @event.message.should == "Some text"
+    end
+
+    it "should not ignore any tags only prefixed by other tags" do
+      filter << LogAgent::Event.new(:message => "[other_tag=foo] [op=abc] A message")
+      @event.message.should == "[other_tag=foo] A message"
+    end
+
+    it  "should assign the tag value to the configured field" do
+      filter << LogAgent::Event.new(:message => "[other_tag=foo] [op=1234] [foo=value] A message")
+      @event.op_id.should == "1234"
+    end
+  end
+end
+


### PR DESCRIPTION
Add a filter to parse [op=xyz] from log messages and set it as an
@op_id field on the event.