### PR TITLE
Tag primary log lines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    log_agent (1.9.2)
+    log_agent (1.10.0)
       amq-protocol (= 1.9.2)
       amqp (~> 1.5.0)
       daemons (~> 1.1.8)

--- a/lib/log_agent.rb
+++ b/lib/log_agent.rb
@@ -30,6 +30,7 @@ module LogAgent
     autoload 'RailsLogTagParser',     'log_agent/filter/rails_log_tag_parser'
     autoload 'RailsOpIdParser',       'log_agent/filter/rails_op_id_parser'
     autoload 'MysqlSlow',             'log_agent/filter/mysql_slow'
+    autoload 'DelayedJob',            'log_agent/filter/delayed_job'
   end
   module Output
     autoload 'ElasticsearchRiver', 'log_agent/output/elasticsearch_river'

--- a/lib/log_agent/filter/delayed_job.rb
+++ b/lib/log_agent/filter/delayed_job.rb
@@ -1,0 +1,14 @@
+module LogAgent::Filter
+  class DelayedJob < Base
+
+    include LogAgent::LogHelper
+
+    def << event
+      if event.message =~ /^Finished Job \[id=\d+\] after [\d.]+ms/
+        event.primary = true
+      end
+
+      emit event
+    end
+  end
+end

--- a/lib/log_agent/filter/rails.rb
+++ b/lib/log_agent/filter/rails.rb
@@ -26,6 +26,7 @@ module LogAgent::Filter
       if event.message =~ /^Completed (\d+) .* in (\d+(?:\.\d+)?)ms/
         event.fields['rails_status'] = $1.to_i
         event.fields['rails_duration']['total'] = $2.to_f
+        event.primary = true
       end
 
       if event.message =~ /^Completed .*Views: ([\d.]+)ms/

--- a/lib/log_agent/version.rb
+++ b/lib/log_agent/version.rb
@@ -1,3 +1,3 @@
 module LogAgent
-  VERSION = '1.9.2'
+  VERSION = '1.10.0'
 end

--- a/spec/data/delayed_job_entries/entry1.log
+++ b/spec/data/delayed_job_entries/entry1.log
@@ -1,0 +1,1 @@
+Starting Job [id=534] [payload=Delayed::PerformableMethod] [name=Object#sleep]

--- a/spec/data/delayed_job_entries/entry2.log
+++ b/spec/data/delayed_job_entries/entry2.log
@@ -1,0 +1,1 @@
+Finished Job [id=534] after 234ms

--- a/spec/functional/filter/delayed_job_spec.rb
+++ b/spec/functional/filter/delayed_job_spec.rb
@@ -1,0 +1,25 @@
+# coding: utf-8
+require 'spec_helper'
+
+describe LogAgent::Filter::DelayedJob do
+  let(:sink) { mock("MySinkObject", :<< => nil) }
+  let(:filter) { LogAgent::Filter::DelayedJob.new sink }
+
+  it "should be created with new <sink>" do
+    filter.sink.should == [sink]
+  end
+
+  describe "parsing" do
+    load_entries!('delayed_job_entries')
+
+    it "should pass the entry through to the sink" do
+      sink.should_receive(:<<).with(entry1)
+      filter << entry1
+    end
+
+    it "should mark the final entry as primary" do
+      entry1.primary.should == nil
+      entry2.primary.should == true
+    end
+  end
+end


### PR DESCRIPTION
Tag the primary log line (i.e. the last one) for web requests and
delayed job logs. This will make it easier to filter down to a single
log line per operation.